### PR TITLE
[fix] perfomance/ Change list to array

### DIFF
--- a/libvshadow/libvshadow_store_descriptor.c
+++ b/libvshadow/libvshadow_store_descriptor.c
@@ -107,8 +107,9 @@ int libvshadow_store_descriptor_initialize(
 
 		return( -1 );
 	}
-	if( libcdata_list_initialize(
-	     &( ( *store_descriptor )->block_descriptors_list ),
+	if( libcdata_array_initialize(
+	     &( ( *store_descriptor )->block_descriptors_array ),
+		 0,
 	     error ) != 1 )
 	{
 		libcerror_error_set(
@@ -215,10 +216,10 @@ on_error:
 			 NULL,
 			 NULL );
 		}
-		if( ( *store_descriptor )->block_descriptors_list != NULL )
+		if( ( *store_descriptor )->block_descriptors_array != NULL )
 		{
-			libcdata_list_free(
-			 &( ( *store_descriptor )->block_descriptors_list ),
+			libcdata_array_free(
+			 &( ( *store_descriptor )->block_descriptors_array ),
 			 NULL,
 			 NULL );
 		}
@@ -306,8 +307,8 @@ int libvshadow_store_descriptor_free(
 
 			result = -1;
 		}
-		if( libcdata_list_free(
-		     &( ( *store_descriptor )->block_descriptors_list ),
+		if( libcdata_array_free(
+		     &( ( *store_descriptor )->block_descriptors_array ),
 		     (int (*)(intptr_t **, libcerror_error_t **)) &libvshadow_block_descriptor_free,
 		     error ) != 1 )
 		{
@@ -1520,7 +1521,7 @@ int libvshadow_store_descriptor_read_store_block_list(
 	static char *function                           = "libvshadow_store_descriptor_read_store_block_list";
 	uint16_t block_size                             = 0;
 	int result                                      = 0;
-
+	int entry_index                                 = 0;
 	if( store_descriptor == NULL )
 	{
 		libcerror_error_set(
@@ -1641,8 +1642,9 @@ int libvshadow_store_descriptor_read_store_block_list(
 
 				goto on_error;
 			}
-			if( libcdata_list_append_value(
-			     store_descriptor->block_descriptors_list,
+			if( libcdata_array_append_entry(
+			     store_descriptor->block_descriptors_array,
+				 &entry_index,
 			     (intptr_t *) block_descriptor,
 			     error ) != 1 )
 			{
@@ -3283,8 +3285,8 @@ int libvshadow_store_descriptor_get_number_of_blocks(
 		return( -1 );
 	}
 #endif
-	if( libcdata_list_get_number_of_elements(
-	     store_descriptor->block_descriptors_list,
+	if( libcdata_array_get_number_of_entries(
+	     store_descriptor->block_descriptors_array,
 	     number_of_blocks,
 	     error ) != 1 )
 	{
@@ -3381,8 +3383,8 @@ int libvshadow_store_descriptor_get_block_descriptor_by_index(
 		return( -1 );
 	}
 #endif
-	if( libcdata_list_get_value_by_index(
-	     store_descriptor->block_descriptors_list,
+	if( libcdata_array_get_entry_by_index(
+	     store_descriptor->block_descriptors_array,
 	     block_index,
 	     (intptr_t **) block_descriptor,
 	     error ) != 1 )

--- a/libvshadow/libvshadow_store_descriptor.h
+++ b/libvshadow/libvshadow_store_descriptor.h
@@ -104,7 +104,7 @@ struct libvshadow_store_descriptor
 
 	/* The block descriptors list
 	 */
-	libcdata_list_t *block_descriptors_list;
+	libcdata_array_t *block_descriptors_array;
 
 	/* The forward block descriptors B-tree
 	 */


### PR DESCRIPTION
I profiled FastDelta and find, that 98,7% we spend to iterate by list. Its apears, because list of blocks stored in list. When we call **libvshadow_store_get_block_by_index**, than we should iterate from 0 to index. 
There is result of profiling in program VerySleepy(http://www.codersnotes.com/sleepy/):
[captureFastDelta.zip](https://github.com/ReplibitLLC/libvshadow/files/1394584/captureFastDelta.zip)

Profile GenerateFissionBitmap:
![perf1](https://user-images.githubusercontent.com/20031706/31718785-ca69a402-b419-11e7-96d3-5e8e365d7ef4.png)
Profile libvshadow_store_get_block_by_index:
![perf2](https://user-images.githubusercontent.com/20031706/31718801-d990490e-b419-11e7-9831-2bee3a1fed07.png)

I change **list** to **array**.

