### PR TITLE
[fix] Cannot open volume, operating string out of bounds

### DIFF
--- a/libvshadow/libvshadow_store_descriptor.h
+++ b/libvshadow/libvshadow_store_descriptor.h
@@ -86,6 +86,14 @@ struct libvshadow_store_descriptor
 	 */
 	uint32_t attribute_flags;
 
+	/* The copy identifier string
+	 */
+	uint8_t *copy_identifier_string;
+
+	/* The copy identifier string size
+	 */
+	uint16_t copy_identifier_string_size;
+
 	/* The operating machine string
 	 */
 	uint8_t *operating_machine_string;

--- a/libvshadow/vshadow_store.h
+++ b/libvshadow/vshadow_store.h
@@ -108,11 +108,6 @@ struct vshadow_store_information
 	 * Consists of 4 bytes
 	 */
 	uint8_t attribute_flags[ 4 ];
-
-	/* Unknown
-	 * Consists of 4 bytes
-	 */
-	uint8_t unknown10[ 4 ];
 };
 
 typedef struct vshadow_store_block_header vshadow_store_block_header_t;


### PR DESCRIPTION
There is bug:

    Unable to open volume \\?\Volume{88b8eb89-1df3-11e7-8bc2-000c29c41622} (libvshadow_store_descriptor_read_store_header: operating machine string size value out of bounds.
    libvshadow_volume_open_read: unable to read store: 2 header.
    libvshadow_volume_open_file_io_handle: unable to read from file IO handle.
    libvshadow_volume_open_wide: unable to open volume: \\?\Volume{88b8eb89-1df3-11e7-8bc2-000c29c41622}.)

It appears because libvshadow wrong interpreterpath field with name **unknown10**
![screenshot-2](https://user-images.githubusercontent.com/20031706/32233268-0d7cfe3c-be6b-11e7-9e55-d4ac5d758cad.png)
Its null-terminated utf-16 string guid.